### PR TITLE
Add single-file customization for pet landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 # Configuração rápida (plug-and-play)
 
-1) **Abra `config.js`** e edite:
-- `siteName`, `tagline`, `description`
-- `whatsappNumber` (formato DDI+DDD+número, só dígitos, ex.: `5511999999999`)
-- `addressHtml` e `openingHours`
+1) **Abra `config.js`** e personalize:
+- `siteName` e o objeto `brand` (nome que aparece no cabeçalho/rodapé)
+- `whatsappNumber`, `addressHtml` e `openingHours`
+- Blocos `navigation`, `hero`, `services`, `plans`, `testimonials`, `gallery`, `faq`, `contact` e `footer` para trocar textos, botões e listas
 - `form.provider` → `"whatsapp"` (recomendado), `"netlify"`, `"formspree"`, `"emailjs"`
-- `pixels` (GA4, Facebook, TikTok), `seo.ogImage` e `seo.faviconEmoji` (opcional)
+- `pixels` (GA4, Facebook, TikTok) e `seo` (título, descrição, favicon emoji, imagem de compartilhamento)
 
 2) **Troque as fotos (opcional)**: 
 Coloque arquivos na pasta `assets/images/` que eles substituem as imagens padrão automaticamente:

--- a/TUTORIAL.txt
+++ b/TUTORIAL.txt
@@ -17,16 +17,21 @@ TAMANHOS RECOMENDADOS
 
 PASSO 1 — EDITAR CONFIG.JS
 1. Abra o arquivo config.js (pode ser no Bloco de Notas mesmo).
-2. Troque:
-   - siteName → seu nome/loja
-   - tagline e description → seu “slogan” e descrição curta
+2. No topo altere os dados gerais:
+   - siteName e brand.primary/secondary → como o nome aparece no cabeçalho e rodapé
    - whatsappNumber → coloque só números (DDI + DDD + número), ex.: 5511999999999
-   - addressHtml → seu endereço (pode usar quebra de linha <br/>)
-   - openingHours → ajuste os horários
-   - social.instagram / social.tiktok → seus links (se quiser)
-   - form.provider → escolha UMA opção: "whatsapp" (mais fácil), "netlify", "formspree", "emailjs"
-3. (Opcional) pixels → GA4, Facebook e TikTok (cole seus códigos para medir visitas).
-4. (Opcional) seo.ogImage → link absoluto de uma imagem 1200×630 para aparecer bonita ao compartilhar.
+   - addressHtml → endereço (aceita <br/> para quebrar linha)
+   - openingHours → dias e horários da sua operação
+3. Logo abaixo edite cada bloco de conteúdo:
+   - navigation → textos e links do menu/CTA
+   - hero → título, destaque, botões, badges e formulário da oferta
+   - services, plans, testimonials, gallery, faq → títulos e listas dos cards
+   - contact → opções do formulário, botões e badges
+   - footer → texto legal e links do rodapé
+4. Redes sociais: preencha social.instagram / social.tiktok se quiser mostrar.
+5. Formulário: form.provider define como você recebe ("whatsapp", "netlify", "formspree" ou "emailjs").
+6. (Opcional) pixels → GA4, Facebook e TikTok (cole seus códigos para medir visitas).
+7. (Opcional) seo → título da aba, descrição e imagem para redes sociais (ogImage 1200×630).
 
 PASSO 2 — TROCAR LOGO E FOTOS (OPCIONAL)
 - Logo: coloque seu arquivo em assets/images/logo.png. Pronto.

--- a/config-bind.js
+++ b/config-bind.js
@@ -9,82 +9,417 @@
 /* Liga o config.js ao HTML mantendo o design original */
 (function(){
   const C = window.SITE_CONFIG || {};
-
-  // Favicon emoji
-  if (C.seo && C.seo.faviconEmoji){
-    const link = document.createElement('link'); link.rel="icon";
-    link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>${encodeURIComponent(C.seo.faviconEmoji)}</text></svg>`;
-    document.head.appendChild(link);
-  }
-  // og:image
-  if (C.seo && C.seo.ogImage){
-    const og = document.createElement('meta'); og.setAttribute('property','og:image'); og.content = C.seo.ogImage; document.head.appendChild(og);
-  }
-
-  // Atualiza nome da marca (em todos os locais comuns)
-  const replaceTextAll = (selectorList, text) => {
-    (selectorList || []).forEach(sel => { document.querySelectorAll(sel).forEach(el => el.textContent = text) })
+  const ICONS = {
+    scissors: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 5a3 3 0 1 1-3 3 3 3 0 0 1 3-3m6 0a3 3 0 1 1-3 3 3 3 0 0 1 3-3M2 20l8-8m4 0 8 8M2 20l6-2 3 3"/></svg>',
+    steth: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3v6a4 4 0 0 0 8 0V3h2v6a6 6 0 1 1-12 0V3z"/><circle cx="19" cy="12" r="3"/><path d="M19 15v2a6 6 0 0 1-6 6h-1"/></svg>',
+    house: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 10 12 3l8 7v10a1 1 0 0 1-1 1h-5v-6H10v6H5a1 1 0 0 1-1-1z"/></svg>',
+    truck: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h11v8H3zM14 10h4l3 3v2h-7z"/><circle cx="7" cy="17" r="2"/><circle cx="17" cy="17" r="2"/></svg>',
+    paw: '<svg viewBox="0 0 64 64" aria-hidden="true"><circle cx="20" cy="20" r="8"/><circle cx="44" cy="20" r="8"/><circle cx="24" cy="40" r="8"/><circle cx="40" cy="40" r="8"/><path d="M32 60c12 0 20-10 12-18-4-4-8-4-12-4s-8 0-12 4c-8 8 0 18 12 18z"/></svg>'
   };
-  if (C.siteName){
-    replaceTextAll(['.brand', '.brand b', 'header .brand', 'footer .brand', 'h1 .brand', 'h1 .site-name', '.site-name'], C.siteName);
-    // também tenta no <title>
-    const title = document.querySelector('title'); if (title && !title.dataset.lock) title.textContent = C.siteName + " • Petshop";
-  }
-  if (C.tagline){
-    const el = document.querySelector('.hero-copy .highlight'); if (el) el.textContent = C.tagline;
-  }
-  if (C.description){
-    // procura o primeiro parágrafo dentro do hero copy que não seja CTA
-    const p = document.querySelector('.hero-copy p'); if (p) p.textContent = C.description;
-  }
 
-  // Endereço
-  if (C.addressHtml){
+  const toDigits = (value) => (value || '').toString().replace(/\D+/g, '');
+  const formatWhatsUrl = (value) => {
+    const digits = toDigits(value);
+    return digits ? `https://wa.me/${digits}` : '#';
+  };
+
+  const setText = (selector, text) => {
+    if (text == null) return;
+    document.querySelectorAll(selector).forEach(el => { el.textContent = text; });
+  };
+
+  const bindMeta = () => {
+    const seo = C.seo || {};
+    if (seo.pageTitle){
+      const title = document.querySelector('title');
+      if (title){
+        title.textContent = seo.pageTitle;
+        title.dataset.lock = 'true';
+      }
+      const ogTitle = document.querySelector('meta[property="og:title"]');
+      if (ogTitle) ogTitle.setAttribute('content', seo.pageTitle);
+    }
+    if (seo.metaDescription){
+      const metaDesc = document.querySelector('meta[name="description"]');
+      if (metaDesc) metaDesc.setAttribute('content', seo.metaDescription);
+      const ogDesc = document.querySelector('meta[property="og:description"]');
+      if (ogDesc) ogDesc.setAttribute('content', seo.metaDescription);
+    }
+    if (seo.ogImage){
+      let og = document.querySelector('meta[property="og:image"]');
+      if (!og){
+        og = document.createElement('meta');
+        og.setAttribute('property', 'og:image');
+        document.head.appendChild(og);
+      }
+      og.setAttribute('content', seo.ogImage);
+    }
+    if (seo.faviconEmoji){
+      const link = document.createElement('link'); link.rel="icon";
+      link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>${encodeURIComponent(seo.faviconEmoji)}</text></svg>`;
+      document.head.appendChild(link);
+    }
+  };
+
+  const bindBrand = () => {
+    const brand = C.brand || {};
+    const primary = brand.primary || C.siteName || '';
+    const secondary = brand.secondary || '';
+    const short = brand.short || primary;
+    setText('header .brand strong', primary);
+    setText('header .brand .sub', secondary);
+    setText('.brand-text', short);
+    setText('.site-footer .brand strong', primary);
+    setText('.site-footer .brand .sub', secondary);
+  };
+
+  const bindNavigation = () => {
+    const navigation = C.navigation || {};
+    const links = navigation.links || [];
+    const desktopLinks = Array.from(document.querySelectorAll('.nav-links a')).filter(a => !a.classList.contains('btn-sm'));
+    desktopLinks.forEach((linkEl, index) => {
+      const data = links[index];
+      if (!data) return;
+      if (data.label != null) linkEl.textContent = data.label;
+      if (data.href) linkEl.setAttribute('href', data.href);
+    });
+    const navCta = document.querySelector('.nav-links a.btn-sm');
+    if (navCta && navigation.cta){
+      if (navigation.cta.label != null) navCta.textContent = navigation.cta.label;
+      if (navigation.cta.href) navCta.setAttribute('href', navigation.cta.href);
+    }
+    const mobileLinks = Array.from(document.querySelectorAll('#mobileMenu a')).filter(a => !a.classList.contains('btn'));
+    mobileLinks.forEach((linkEl, index) => {
+      const data = links[index];
+      if (!data) return;
+      if (data.label != null) linkEl.textContent = data.label;
+      if (data.href) linkEl.setAttribute('href', data.href);
+    });
+    const mobileCta = document.querySelector('#mobileMenu a.btn');
+    if (mobileCta && navigation.cta){
+      if (navigation.cta.label != null) mobileCta.textContent = navigation.cta.label;
+      if (navigation.cta.href) mobileCta.setAttribute('href', navigation.cta.href);
+    }
+    const footerLinks = C.footer && C.footer.links || [];
+    const footerEls = document.querySelectorAll('.footer-links a');
+    footerEls.forEach((el, index) => {
+      const data = footerLinks[index] || links[index];
+      if (!data) return;
+      if (data.label != null) el.textContent = data.label;
+      if (data.href) el.setAttribute('href', data.href);
+    });
+  };
+
+  const bindHero = () => {
+    const hero = C.hero || {};
+    const h1 = document.querySelector('.hero-copy h1');
+    if (h1){
+      const title = hero.title || '';
+      const highlight = hero.highlight || C.tagline || '';
+      if (title && highlight){
+        h1.innerHTML = `${title} <span class="highlight">${highlight}</span>`;
+      } else if (title){
+        h1.textContent = title;
+      }
+    }
+    if (hero.description) setText('.hero-copy p', hero.description);
+    if (hero.trustBadges){
+      const ul = document.querySelector('.hero-copy .trust');
+      if (ul){
+        ul.innerHTML = hero.trustBadges.map(item => `\n            <li>✔️ ${item}</li>`).join('');
+      }
+    }
+    if (hero.primaryCTA){
+      const btn = document.querySelector('.hero-copy .btn.btn-lg');
+      if (btn){
+        if (hero.primaryCTA.label != null) btn.textContent = hero.primaryCTA.label;
+        if (hero.primaryCTA.href) btn.setAttribute('href', hero.primaryCTA.href);
+      }
+    }
+    if (hero.secondaryCTA){
+      const btn = document.querySelector('.hero-copy .btn.ghost');
+      if (btn){
+        if (hero.secondaryCTA.label != null) btn.textContent = hero.secondaryCTA.label;
+        if (hero.secondaryCTA.href) btn.setAttribute('href', hero.secondaryCTA.href);
+      }
+    }
+
+    const promo = hero.promo || {};
+    const card = document.querySelector('.hero-card');
+    if (card){
+      const titleEl = card.querySelector('.card-title');
+      if (titleEl && promo.title != null) titleEl.textContent = promo.title;
+      const descEl = card.querySelector('p');
+      if (descEl && promo.description){
+        let html = promo.description;
+        if (promo.highlight){
+          if (html.includes('{highlight}')){
+            html = html.replace(/\{highlight\}/g, `<strong>${promo.highlight}</strong>`);
+          } else {
+            html = `${html} <strong>${promo.highlight}</strong>`;
+          }
+        }
+        descEl.innerHTML = html;
+      }
+      const leadForm = card.querySelector('form');
+      if (leadForm && promo.leadForm){
+        const spans = leadForm.querySelectorAll('label span');
+        if (spans[0] && promo.leadForm.nameLabel != null) spans[0].textContent = promo.leadForm.nameLabel;
+        if (spans[1] && promo.leadForm.whatsappLabel != null) spans[1].textContent = promo.leadForm.whatsappLabel;
+        const inputs = leadForm.querySelectorAll('input');
+        if (inputs[0]){
+          if (promo.leadForm.namePlaceholder != null){
+            inputs[0].placeholder = promo.leadForm.namePlaceholder;
+          } else if (promo.leadForm.nameLabel != null && inputs[0].placeholder.toLowerCase().startsWith('ex.:')){
+            inputs[0].placeholder = `Ex.: ${promo.leadForm.nameLabel}`;
+          }
+        }
+        if (inputs[1]){
+          if (promo.leadForm.whatsappPlaceholder != null){
+            inputs[1].placeholder = promo.leadForm.whatsappPlaceholder;
+          } else if (promo.leadForm.whatsappLabel != null && inputs[1].placeholder.includes('9')){
+            inputs[1].placeholder = `(11) 99999-9999`;
+          }
+        }
+        const button = leadForm.querySelector('button');
+        if (button && promo.leadForm.buttonLabel != null) button.textContent = promo.leadForm.buttonLabel;
+        const disclaimer = leadForm.querySelector('small');
+        if (disclaimer && promo.disclaimer != null) disclaimer.textContent = promo.disclaimer;
+      }
+    }
+  };
+
+  const iconMarkup = (name) => ICONS[name?.toLowerCase?.()] || ICONS.paw;
+
+  const bindServices = () => {
+    const services = C.services || {};
+    if (services.title != null) setText('#servicos .section-header h2', services.title);
+    if (services.subtitle != null) setText('#servicos .section-header p', services.subtitle);
+    const grid = document.querySelector('#servicos .grid.cards');
+    if (grid && Array.isArray(services.items)){
+      grid.innerHTML = '';
+      services.items.forEach(item => {
+        const article = document.createElement('article');
+        article.className = 'card glass';
+        const icon = document.createElement('div'); icon.className = 'icon'; icon.innerHTML = iconMarkup(item.icon);
+        const h3 = document.createElement('h3'); h3.textContent = item.title || '';
+        const p = document.createElement('p'); p.textContent = item.description || '';
+        article.appendChild(icon);
+        article.appendChild(h3);
+        article.appendChild(p);
+        if (Array.isArray(item.features) && item.features.length){
+          const ul = document.createElement('ul'); ul.className = 'features';
+          item.features.forEach(feature => {
+            const li = document.createElement('li'); li.textContent = feature; ul.appendChild(li);
+          });
+          article.appendChild(ul);
+        }
+        grid.appendChild(article);
+      });
+    }
+  };
+
+  const bindPlans = () => {
+    const plans = C.plans || {};
+    if (plans.title != null) setText('#planos .section-header h2', plans.title);
+    if (plans.subtitle != null) setText('#planos .section-header p', plans.subtitle);
+    const grid = document.querySelector('#planos .grid.plans');
+    if (grid && Array.isArray(plans.items)){
+      grid.innerHTML = '';
+      plans.items.forEach(plan => {
+        const article = document.createElement('article');
+        article.className = 'plan glass';
+        if (plan.highlight) article.classList.add('highlight');
+        if (plan.badge){
+          const badge = document.createElement('div'); badge.className = 'badge'; badge.textContent = plan.badge; article.appendChild(badge);
+        }
+        const h3 = document.createElement('h3'); h3.textContent = plan.name || '';
+        const price = document.createElement('p'); price.className = 'price';
+        const prefix = document.createElement('span'); prefix.textContent = plan.pricePrefix || '';
+        const amount = document.createTextNode(plan.price || '');
+        price.appendChild(prefix);
+        price.appendChild(amount);
+        if (plan.priceSuffix){
+          const suffix = document.createElement('span'); suffix.className = 'per'; suffix.textContent = plan.priceSuffix; price.appendChild(suffix);
+        }
+        article.appendChild(h3);
+        article.appendChild(price);
+        if (Array.isArray(plan.features) && plan.features.length){
+          const ul = document.createElement('ul');
+          plan.features.forEach(feature => {
+            const li = document.createElement('li'); li.textContent = feature; ul.appendChild(li);
+          });
+          article.appendChild(ul);
+        }
+        const btn = document.createElement('a'); btn.className = 'btn';
+        btn.textContent = plan.buttonLabel || 'Escolher';
+        btn.setAttribute('href', plan.buttonHref || '#contato');
+        article.appendChild(btn);
+        grid.appendChild(article);
+      });
+    }
+  };
+
+  const bindTestimonials = () => {
+    const testimonials = C.testimonials || {};
+    if (testimonials.title != null) setText('#depoimentos .section-header h2', testimonials.title);
+    const grid = document.querySelector('#depoimentos .grid.testimonials');
+    if (grid && Array.isArray(testimonials.items)){
+      grid.innerHTML = '';
+      testimonials.items.forEach(item => {
+        const figure = document.createElement('figure'); figure.className = 't-card glass';
+        const block = document.createElement('blockquote'); block.textContent = item.quote || '';
+        const caption = document.createElement('figcaption'); caption.textContent = item.author || '';
+        figure.appendChild(block);
+        figure.appendChild(caption);
+        grid.appendChild(figure);
+      });
+    }
+  };
+
+  const bindGallery = () => {
+    const gallery = C.gallery || {};
+    const section = document.querySelector('#galeria .section-header');
+    if (!section) return;
+    const h2 = section.querySelector('h2'); if (h2 && gallery.title != null) h2.textContent = gallery.title;
+    const p = section.querySelector('p'); if (p && gallery.subtitle != null) p.textContent = gallery.subtitle;
+  };
+
+  const bindFaq = () => {
+    const faq = C.faq || {};
+    const faqContainer = document.querySelector('.faq');
+    if (!faqContainer) return;
+    const header = faqContainer.previousElementSibling;
+    if (header && faq.title != null){
+      const h2 = header.querySelector('h2'); if (h2) h2.textContent = faq.title;
+    }
+    if (Array.isArray(faq.items)){
+      faqContainer.innerHTML = '';
+      faq.items.forEach(item => {
+        const details = document.createElement('details');
+        const summary = document.createElement('summary'); summary.textContent = item.question || '';
+        const p = document.createElement('p'); p.textContent = item.answer || '';
+        details.appendChild(summary);
+        details.appendChild(p);
+        faqContainer.appendChild(details);
+      });
+    }
+  };
+
+  const bindContact = () => {
+    const contact = C.contact || {};
+    if (contact.title != null) setText('#contato .section-header h2', contact.title);
+    if (contact.subtitle != null) setText('#contato .section-header p', contact.subtitle);
+
+    const select = document.querySelector('#contactForm select[name="servico"]');
+    if (select && Array.isArray(contact.serviceOptions)){
+      const placeholder = select.querySelector('option[value=""]');
+      select.innerHTML = '';
+      const defaultOption = document.createElement('option'); defaultOption.value = ''; defaultOption.textContent = 'Selecione';
+      select.appendChild(defaultOption);
+      contact.serviceOptions.forEach(option => {
+        const opt = document.createElement('option'); opt.textContent = option; select.appendChild(opt);
+      });
+    }
+
+    const badges = document.querySelector('.contact-badges');
+    if (badges && Array.isArray(contact.badges)){
+      badges.innerHTML = contact.badges.map(label => `<span class="badge">${label}</span>`).join('');
+    }
+
+    const primaryBtn = document.querySelector('#contactForm .actions .btn');
+    if (primaryBtn && contact.primaryButton){
+      if (contact.primaryButton.label != null) primaryBtn.textContent = contact.primaryButton.label;
+    }
+    const secondaryBtn = document.querySelector('#contactForm .actions .btn.ghost');
+    if (secondaryBtn && contact.secondaryButton){
+      if (contact.secondaryButton.label != null) secondaryBtn.textContent = contact.secondaryButton.label;
+      if (contact.secondaryButton.href){
+        secondaryBtn.setAttribute('href', contact.secondaryButton.href);
+      } else {
+        secondaryBtn.setAttribute('href', formatWhatsUrl(C.whatsappNumber));
+      }
+    } else if (secondaryBtn){
+      secondaryBtn.setAttribute('href', formatWhatsUrl(C.whatsappNumber));
+    }
+
+    const disclaimer = document.querySelector('#contactForm small');
+    if (disclaimer && contact.disclaimer != null) disclaimer.textContent = contact.disclaimer;
+
     const aside = document.querySelector('#contato aside');
     if (aside){
-      const p = aside.querySelector('p');
-      if (p) p.innerHTML = C.addressHtml;
+      if (C.addressHtml != null){
+        const p = aside.querySelector('p'); if (p) p.innerHTML = C.addressHtml;
+      }
+      if (Array.isArray(C.openingHours)){
+        const list = aside.querySelector('.hours');
+        if (list){
+          list.innerHTML = C.openingHours.map(item => `<li><strong>${item.day}</strong> ${item.hours}</li>`).join('');
+        }
+      }
     }
-  }
-  // Horários
-  if (Array.isArray(C.openingHours)){
-    const ul = document.querySelector('#contato .hours');
-    if (ul){
-      ul.innerHTML = C.openingHours.map(h => `<li><strong>${h.day}</strong> ${h.hours}</li>`).join('');
+  };
+
+  const bindFooter = () => {
+    const footer = C.footer || {};
+    if (footer.legal){
+      const legal = footer.legal.replace('{year}', new Date().getFullYear());
+      const el = document.querySelector('.site-footer p.muted');
+      if (el) el.textContent = legal;
     }
-  }
+  };
 
-  // Sociais
-  if (C.social){
-    const ig = document.querySelector('a[href*="instagram.com"]'); if (ig && C.social.instagram) ig.href = C.social.instagram;
-    const tt = document.querySelector('a[href*="tiktok.com"]');    if (tt && C.social.tiktok)    tt.href = C.social.tiktok;
-  }
+  const bindSocial = () => {
+    if (C.social){
+      const ig = document.querySelector('a[href*="instagram.com"]'); if (ig && C.social.instagram) ig.href = C.social.instagram;
+      const tt = document.querySelector('a[href*="tiktok.com"]');    if (tt && C.social.tiktok)    tt.href = C.social.tiktok;
+    }
+  };
 
-  // Pixels
-  if (C.pixels && C.pixels.ga4){
-    const s = document.createElement('script'); s.async = true;
-    s.src = `https://www.googletagmanager.com/gtag/js?id=${C.pixels.ga4}`;
-    document.head.appendChild(s);
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){ dataLayer.push(arguments); }
-    gtag('js', new Date()); gtag('config', C.pixels.ga4);
-  }
-  if (C.pixels && C.pixels.facebook){
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script',
-    'https://connect.facebook.net/en_US/fbevents.js'); fbq('init', C.pixels.facebook); fbq('track', 'PageView');
-  }
-  if (C.pixels && C.pixels.tiktok){
-    !function (w, d, t) { w.TiktokAnalyticsObject = t; var ttq = w[t] = w[t] || [];
-    ttq.methods = ["page","track","identify","instances","debug","on","off","once","ready","alias","group","enableCookie","disableCookie"];
-    ttq.setAndDefer = function (t, e) { t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))) } };
-    for (var i = 0; i < ttq.methods.length; i++) ttq.setAndDefer(ttq, ttq.methods[i]);
-    ttq.instance = function (t) { for (var e = ttq._i = ttq._i || {}, n = 0; n < ttq.methods.length; n++) ttq.setAndDefer(e[t] = [], ttq.methods[n]); return e[t] };
-    ttq.load = function (e, n) { var i = "https://analytics.tiktok.com/i18n/pixel/events.js";
-    ttq._t = ttq._t || []; ttq._t.push([e, n]); var a = d.createElement("script"); a.type = "text/javascript";
-    a.async = !0; a.src = i; var s = d.getElementsByTagName("script")[0]; s.parentNode.insertBefore(a, s) };
-    ttq.load(C.pixels.tiktok); ttq.page(); }(window, document, 'ttq');
-  }
+  const bindSeo = () => {
+    bindMeta();
+  };
+
+  const bindPixels = () => {
+    if (C.pixels && C.pixels.ga4){
+      const s = document.createElement('script'); s.async = true;
+      s.src = `https://www.googletagmanager.com/gtag/js?id=${C.pixels.ga4}`;
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ window.dataLayer.push(arguments); }
+      gtag('js', new Date()); gtag('config', C.pixels.ga4);
+    }
+    if (C.pixels && C.pixels.facebook){
+      !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+      n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js'); window.fbq('init', C.pixels.facebook); window.fbq('track', 'PageView');
+    }
+    if (C.pixels && C.pixels.tiktok){
+      !function (w, d, t) { w.TiktokAnalyticsObject = t; var ttq = w[t] = w[t] || [];
+      ttq.methods = ["page","track","identify","instances","debug","on","off","once","ready","alias","group","enableCookie","disableCookie"];
+      ttq.setAndDefer = function (t, e) { t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))) } };
+      for (var i = 0; i < ttq.methods.length; i++) ttq.setAndDefer(ttq, ttq.methods[i]);
+      ttq.instance = function (t) { for (var e = ttq._i = ttq._i || {}, n = 0; n < ttq.methods.length; n++) ttq.setAndDefer(e[t] = [], ttq.methods[n]); return e[t] };
+      ttq.load = function (e, n) { var i = "https://analytics.tiktok.com/i18n/pixel/events.js";
+      ttq._t = ttq._t || []; ttq._t.push([e, n]); var a = d.createElement("script"); a.type = "text/javascript";
+      a.async = !0; a.src = i; var s = d.getElementsByTagName("script")[0]; s.parentNode.insertBefore(a, s) };
+      ttq.load(C.pixels.tiktok); ttq.page(); }(window, document, 'ttq');
+    }
+  };
+
+  bindSeo();
+  bindBrand();
+  bindNavigation();
+  bindHero();
+  bindServices();
+  bindPlans();
+  bindTestimonials();
+  bindGallery();
+  bindFaq();
+  bindContact();
+  bindFooter();
+  bindSocial();
+  bindPixels();
 })();

--- a/config.js
+++ b/config.js
@@ -10,9 +10,15 @@
    CONFIGURAÇÃO RÁPIDA (plug-and-play)
    ======================= */
 window.SITE_CONFIG = {
-  siteName: "AuMiau Petshop",
-  tagline: "Banho & Tosa, Veterinário e muito carinho.",
-  description: "Cuidamos do seu pet com carinho e profissionalismo. Agende online!",
+  /* =======================
+     Identidade e dados gerais
+     ======================= */
+  siteName: "AuMiau Petshop", // Usado em títulos/metadados
+  brand: {
+    primary: "AuMiau",       // Nome exibido em destaque
+    secondary: "Petshop",    // Palavra pequena ao lado do nome
+    short: "AuMiau"          // Versão curta (menu mobile, favicon etc.)
+  },
   whatsappNumber: "5511999999999", // DDI+DDD+número (somente dígitos)
   addressHtml: "Rua dos Pets, 123 — Centro<br/>Sua Cidade • SP",
   openingHours: [
@@ -20,6 +26,199 @@ window.SITE_CONFIG = {
     { day: "Sábado:",  hours: "9h às 16h" },
     { day: "Domingo:", hours: "plantão veterinário" }
   ],
+
+  navigation: {
+    links: [
+      { label: "Serviços", href: "#servicos" },
+      { label: "Planos", href: "#planos" },
+      { label: "Depoimentos", href: "#depoimentos" },
+      { label: "Galeria", href: "#galeria" }
+    ],
+    cta: { label: "Agendar", href: "#contato" }
+  },
+
+  hero: {
+    title: "Cuidado completo para",
+    highlight: "quem te ama",
+    description: "Banho & tosa, veterinário, creche e delivery. Tudo em um só lugar, com profissionais apaixonados por pets.",
+    trustBadges: [
+      "Equipe certificada",
+      "Produtos hipoalergênicos",
+      "Retirada e entrega"
+    ],
+    primaryCTA: { label: "Agendar agora", href: "#contato" },
+    secondaryCTA: { label: "Ver serviços", href: "#servicos" },
+    promo: {
+      title: "Promo de estreia",
+      description: "Banho & tosa com {highlight} na primeira visita.",
+      highlight: "15% OFF",
+      leadForm: {
+        nameLabel: "Seu nome",
+        namePlaceholder: "Ex.: Ana Souza",
+        whatsappLabel: "WhatsApp",
+        whatsappPlaceholder: "(11) 99999-9999",
+        buttonLabel: "Quero meu desconto"
+      },
+      disclaimer: "Sem spam. Entraremos em contato por WhatsApp."
+    }
+  },
+
+  services: {
+    title: "Nossos serviços",
+    subtitle: "Do banho ao check-up, tudo para o bem-estar do seu melhor amigo.",
+    items: [
+      {
+        icon: "scissors",
+        title: "Banho & Tosa",
+        description: "Corte higiênico, tosa na tesoura ou máquina, hidratação e perfumação.",
+        features: [
+          "Secagem com protetor auricular",
+          "Produtos hipoalergênicos",
+          "Relatório pós-atendimento"
+        ]
+      },
+      {
+        icon: "steth",
+        title: "Veterinário",
+        description: "Consultas, vacinas e exames com profissionais credenciados.",
+        features: [
+          "Teletriagem gratuita",
+          "Carteirinha digital",
+          "Parcerias laboratoriais"
+        ]
+      },
+      {
+        icon: "house",
+        title: "Creche & Hotel",
+        description: "Ambiente seguro e monitorado para brincar e descansar.",
+        features: [
+          "Monitoração por câmera",
+          "Enriquecimento ambiental",
+          "Relatórios diários"
+        ]
+      },
+      {
+        icon: "truck",
+        title: "Delivery",
+        description: "Retiramos e entregamos seu pet em casa. Rações e acessórios sob demanda.",
+        features: [
+          "Agendamento via WhatsApp",
+          "Pagamentos digitais",
+          "Roteirização inteligente"
+        ]
+      }
+    ]
+  },
+
+  plans: {
+    title: "Planos e pacotes",
+    subtitle: "Economize com pacotes mensais e vantagens exclusivas.",
+    items: [
+      {
+        name: "Essencial",
+        pricePrefix: "R$",
+        price: "79",
+        priceSuffix: "/banho",
+        features: [
+          "Banho básico",
+          "Escovação de pelagem",
+          "Perfume hipoalergênico"
+        ],
+        buttonLabel: "Escolher",
+        buttonHref: "#contato"
+      },
+      {
+        name: "Premium",
+        pricePrefix: "R$",
+        price: "129",
+        priceSuffix: "/sessão",
+        features: [
+          "Banho & tosa completa",
+          "Hidratação + limpeza auricular",
+          "Laço ou gravatinha"
+        ],
+        badge: "Mais popular",
+        highlight: true,
+        buttonLabel: "Escolher",
+        buttonHref: "#contato"
+      },
+      {
+        name: "VIP Mensal",
+        pricePrefix: "R$",
+        price: "349",
+        priceSuffix: "/mês",
+        features: [
+          "3 banhos mensais",
+          "1 tosa por mês",
+          "Retirada e entrega grátis"
+        ],
+        buttonLabel: "Escolher",
+        buttonHref: "#contato"
+      }
+    ]
+  },
+
+  testimonials: {
+    title: "Quem confia, recomenda",
+    items: [
+      { quote: "Meu cãozinho nunca voltou tão cheiroso. Atendimento impecável!", author: "— Júlia M." },
+      { quote: "A creche foi uma salvação nos dias corridos. Ele chega cansado e feliz.", author: "— Caio M." },
+      { quote: "Gostei da carteirinha digital e do relatório após a consulta.", author: "— Renata M." }
+    ]
+  },
+
+  gallery: {
+    title: "Nossos momentos",
+    subtitle: "Alguns registros de quem passa por aqui."
+  },
+
+  faq: {
+    title: "Perguntas frequentes",
+    items: [
+      {
+        question: "Quais vacinas são exigidas para a creche?",
+        answer: "Exigimos vacinação em dia (V8/V10, raiva e tosse dos canis) e controle antipulgas/carrapatos."
+      },
+      {
+        question: "Como funciona a retirada e entrega?",
+        answer: "Agendamos via WhatsApp e passamos em horários combinados. Cobrança por raio de distância."
+      },
+      {
+        question: "Vocês atendem gatos?",
+        answer: "Sim! Temos sala separada, com manejo gentil e produtos específicos para felinos."
+      },
+      {
+        question: "Quais formas de pagamento aceitam?",
+        answer: "Cartão, Pix e link de pagamento. Para planos, oferecemos recorrência mensal."
+      }
+    ]
+  },
+
+  contact: {
+    title: "Agende seu atendimento",
+    subtitle: "Preencha os dados ou chame no WhatsApp. Respondemos rápido!",
+    serviceOptions: [
+      "Banho",
+      "Tosa",
+      "Banho & Tosa",
+      "Consulta Veterinária",
+      "Creche / Hotel"
+    ],
+    badges: ["Pix", "Cartão", "Delivery"],
+    primaryButton: { label: "Enviar pelo WhatsApp" },
+    secondaryButton: { label: "Chamar direto" },
+    disclaimer: "Ao enviar, abriremos uma conversa no WhatsApp com as informações preenchidas."
+  },
+
+  footer: {
+    legal: "© {year} AuMiau Petshop. Todos os direitos reservados.",
+    links: [
+      { label: "Serviços", href: "#servicos" },
+      { label: "Planos", href: "#planos" },
+      { label: "Contato", href: "#contato" }
+    ]
+  },
+
   social: {
     instagram: "",
     tiktok: ""
@@ -35,7 +234,9 @@ window.SITE_CONFIG = {
     tiktok: ""      // TTP123abc...
   },
   seo: {
+    pageTitle: "AuMiau Petshop • Banho & Tosa, Veterinário e Mais",
+    metaDescription: "Cuidamos do seu pet com carinho e profissionalismo. Agende online!",
     ogImage: "", // URL absoluta 1200x630 (opcional)
-    faviconEmoji: "🐾"
+    faviconEmoji: "🐾",
   }
 };


### PR DESCRIPTION
## Summary
- expand `config.js` to cover navigation, hero, services, plans, testimonials, FAQ, contact, footer, and SEO settings
- update the binding script to rebuild page sections from the configuration and wire up analytics/meta tags automatically
- refresh README and TUTORIAL instructions so non-programmers can edit every section from one file

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68deb99c6da08332811036df07947f56