### PR TITLE
Handle missing navigation entries cleanly

### DIFF
--- a/TUTORIAL.txt
+++ b/TUTORIAL.txt
@@ -23,7 +23,7 @@ PASSO 1 — EDITAR CONFIG.JS
    - addressHtml → endereço (aceita <br/> para quebrar linha)
    - openingHours → dias e horários da sua operação
 3. Logo abaixo edite cada bloco de conteúdo:
-   - navigation → textos e links do menu/CTA
+   - navigation → textos e links do menu/CTA (apague um item da lista para remover o link do site)
    - hero → título, destaque, botões, badges e formulário da oferta
    - services, plans, testimonials, gallery, faq → títulos e listas dos cards
    - contact → opções do formulário, botões e badges

--- a/config-bind.js
+++ b/config-bind.js
@@ -79,7 +79,10 @@
     const desktopLinks = Array.from(document.querySelectorAll('.nav-links a')).filter(a => !a.classList.contains('btn-sm'));
     desktopLinks.forEach((linkEl, index) => {
       const data = links[index];
-      if (!data) return;
+      if (!data){
+        linkEl.remove();
+        return;
+      }
       if (data.label != null) linkEl.textContent = data.label;
       if (data.href) linkEl.setAttribute('href', data.href);
     });
@@ -91,7 +94,10 @@
     const mobileLinks = Array.from(document.querySelectorAll('#mobileMenu a')).filter(a => !a.classList.contains('btn'));
     mobileLinks.forEach((linkEl, index) => {
       const data = links[index];
-      if (!data) return;
+      if (!data){
+        linkEl.remove();
+        return;
+      }
       if (data.label != null) linkEl.textContent = data.label;
       if (data.href) linkEl.setAttribute('href', data.href);
     });
@@ -104,7 +110,10 @@
     const footerEls = document.querySelectorAll('.footer-links a');
     footerEls.forEach((el, index) => {
       const data = footerLinks[index] || links[index];
-      if (!data) return;
+      if (!data){
+        el.remove();
+        return;
+      }
       if (data.label != null) el.textContent = data.label;
       if (data.href) el.setAttribute('href', data.href);
     });


### PR DESCRIPTION
## Summary
- remove desktop, mobile, and footer navigation anchors when no matching config entry exists
- update the tutorial to explain that removing an entry from navigation.links hides the link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec1fc7af08332b251097eab2dcc2a