### PR TITLE
Make thank you page configurable via config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - `siteName` e o objeto `brand` (nome que aparece no cabeçalho/rodapé)
 - `whatsappNumber`, `addressHtml` e `openingHours`
 - Blocos `navigation`, `hero`, `services`, `plans`, `testimonials`, `gallery`, `faq`, `contact` e `footer` para trocar textos, botões e listas
+- `thankYouPage` → título, texto e botão da página thanks.html (Netlify usa essa tela após cada envio)
 - Para **esconder seções sem editar HTML**, coloque `enabled: false` nos blocos:
   - `hero.promo.enabled`
   - `services.enabled`
@@ -26,5 +27,7 @@ assets/images/gallery/gallery-8.jpg  (1200x1200)
 ```
 
 3) **Publicar**: Netlify (arrastar pasta), Vercel, GitHub Pages ou Cloudflare Pages.
+
+> **Dica:** Ao usar o Netlify com o formulário nativo, personalize `thankYouPage` no `config.js`. Essa tela (`thanks.html`) é aberta automaticamente depois de cada envio.
 
 > **Observação:** O design original foi mantido. Este pacote só adiciona configuração por arquivo e troca simples de imagens.

--- a/TUTORIAL.txt
+++ b/TUTORIAL.txt
@@ -27,6 +27,7 @@ PASSO 1 — EDITAR CONFIG.JS
    - hero → título, destaque, botões, badges e formulário da oferta
    - services, plans, testimonials, gallery, faq → títulos e listas dos cards
    - contact → opções do formulário, botões e badges
+   - thankYouPage → título, mensagem e botão da página de confirmação (thanks.html)
    - footer → texto legal e links do rodapé
    - **Quer remover uma seção inteira?** Basta colocar `enabled: false` nos blocos `hero.promo`, `services`, `plans`, `testimonials`, `gallery`, `faq` ou `contact` e ela some automaticamente do site.
 4. Redes sociais: preencha social.instagram / social.tiktok se quiser mostrar.
@@ -44,6 +45,7 @@ PASSO 2 — TROCAR LOGO E FOTOS (OPCIONAL)
 PASSO 3 — ESCOLHER COMO RECEBER CONTATOS (form.provider no config.js)
 - "whatsapp" (RECOMENDADO): ao enviar, o cliente abre conversa no seu WhatsApp com a mensagem pronta.
 - "netlify": publique no Netlify (https://app.netlify.com). O formulário aparece no painel do Netlify. A página de sucesso é thanks.html.
+  Personalize `thankYouPage` no `config.js` para mostrar sua mensagem e link de retorno.
 - "formspree": crie um formulário grátis em https://formspree.io e copie o “endpoint” para config.js.
 - "emailjs": exige conta no EmailJS e chave pública. Mostramos um aviso até você plugar o SDK.
 

--- a/config.js
+++ b/config.js
@@ -235,6 +235,12 @@ window.SITE_CONFIG = {
     formspreeEndpoint: "", // ex: https://formspree.io/f/xxxxxxx
     emailjs: { publicKey: "", serviceId: "", templateId: "" }
   },
+  thankYouPage: {
+    title: "Obrigado! 🎉",
+    message: "Recebemos sua mensagem. Em breve entraremos em contato.",
+    backButtonLabel: "Voltar",
+    backButtonHref: "/"
+  },
   pixels: {
     ga4: "",        // G-XXXXXXXXXX
     facebook: "",   // 1234567890

--- a/thanks.html
+++ b/thanks.html
@@ -8,9 +8,56 @@
 </head>
 <body>
   <section class="section container" style="min-height:60vh;display:flex;align-items:center;justify-content:center;flex-direction:column;text-align:center">
-    <h1>Obrigado! 🎉</h1>
-    <p>Recebemos sua mensagem. Em breve entraremos em contato.</p>
-    <p><a class="btn" href="/">Voltar</a></p>
+    <h1 data-thanks="title">Obrigado! 🎉</h1>
+    <p data-thanks="message">Recebemos sua mensagem. Em breve entraremos em contato.</p>
+    <p><a class="btn" data-thanks="back-button" href="/">Voltar</a></p>
   </section>
+  <script src="config.js"></script>
+  <script>
+    (function () {
+      var config = window.SITE_CONFIG || {};
+      var brand = config.brand || {};
+      var brandPieces = [];
+      if (brand.primary) brandPieces.push(brand.primary);
+      if (brand.secondary) brandPieces.push(brand.secondary);
+      var brandName = brandPieces.join(" ").trim();
+      if (!brandName && brand.short) brandName = brand.short;
+      if (!brandName && config.siteName) brandName = config.siteName;
+
+      var thankYou = config.thankYouPage || {};
+
+      var defaultTitle = "Obrigado! 🎉";
+      var defaultMessage = brandName
+        ? "Recebemos sua mensagem. A equipe " + brandName + " falará com você em breve."
+        : "Recebemos sua mensagem. Em breve entraremos em contato.";
+      var defaultButtonLabel = "Voltar para o site";
+      var defaultButtonHref = "/";
+
+      var titleEl = document.querySelector('[data-thanks="title"]');
+      var messageEl = document.querySelector('[data-thanks="message"]');
+      var buttonEl = document.querySelector('[data-thanks="back-button"]');
+
+      if (titleEl) {
+        var titleText = thankYou.title || defaultTitle;
+        titleEl.textContent = titleText;
+        if (titleText) {
+          var pageTitle = brandName ? titleText + " • " + brandName : titleText;
+          document.title = pageTitle;
+        }
+      }
+
+      if (messageEl) {
+        messageEl.textContent = thankYou.message || defaultMessage;
+      }
+
+      if (buttonEl) {
+        buttonEl.textContent = thankYou.backButtonLabel || defaultButtonLabel;
+        var hrefValue = thankYou.backButtonHref || defaultButtonHref;
+        if (hrefValue) {
+          buttonEl.setAttribute("href", hrefValue);
+        }
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a thankYouPage configuration block for the post-form success page
- update thanks.html to load config.js and render thank-you content with fallbacks
- document how to customize the confirmation page and how Netlify uses it after submissions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df31d33f3483329a25ccfe9c9164dc