### PR TITLE
Update contact button label for non-WhatsApp forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - `faq.enabled`
   - `contact.enabled`
 - `form.provider` → `"whatsapp"` (recomendado), `"netlify"`, `"formspree"`, `"emailjs"`
+- Se trocar para um provider que não seja WhatsApp, o botão principal do formulário vira automaticamente "Enviar formulário". Para usar outro texto, sobrescreva `contact.primaryButton.label`.
 - `pixels` (GA4, Facebook, TikTok) e `seo` (título, descrição, favicon emoji, imagem de compartilhamento)
 
 2) **Troque as fotos (opcional)**:

--- a/config-bind.js
+++ b/config-bind.js
@@ -436,8 +436,15 @@
     }
 
     const primaryBtn = document.querySelector('#contactForm .actions .btn');
-    if (primaryBtn && contact.primaryButton){
-      if (contact.primaryButton.label != null) primaryBtn.textContent = contact.primaryButton.label;
+    const provider = (C.form && typeof C.form.provider === 'string') ? C.form.provider.toLowerCase() : 'whatsapp';
+    if (primaryBtn){
+      if (contact.primaryButton && contact.primaryButton.label != null){
+        primaryBtn.textContent = contact.primaryButton.label;
+      }
+      const currentLabel = (primaryBtn.textContent || '').trim();
+      if (provider !== 'whatsapp' && /whatsapp/i.test(currentLabel)){
+        primaryBtn.textContent = 'Enviar formulário';
+      }
     }
     const secondaryBtn = document.querySelector('#contactForm .actions .btn.ghost');
     const fallbackDigits = resolveConfiguredWhatsapp();


### PR DESCRIPTION
## Summary
- automatically replace the contact form primary button label with a neutral message when using non-WhatsApp providers
- document how to override the default label in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3566bcb88332af439112ed420cba