### PR TITLE
Remove placeholder brand logo when injecting dynamic image

### DIFF
--- a/images-local.js
+++ b/images-local.js
@@ -40,6 +40,11 @@
     test.onload = function(){
       var brand = document.querySelector('.brand');
       if (!brand) return;
+      // remove placeholder (.brand-logo) if it's not an <img>
+      var placeholder = brand.querySelector('.brand-logo');
+      if (placeholder && placeholder.tagName !== 'IMG'){
+        placeholder.remove();
+      }
       // cria <img class="brand-logo">
       var img = document.createElement('img');
       img.src = logoPath;

--- a/style.css
+++ b/style.css
@@ -223,5 +223,5 @@ a, button{transition: all .2s ease}
 
 /* === Logo opcional via assets/images/logo.png === */
 .brand-logo{display:none;height:28px;width:auto;vertical-align:middle}
-.brand.has-logo .brand-logo{display:inline-block}
+.brand.has-logo img.brand-logo{display:inline-block}
 .brand.has-logo .brand-text{display:none}


### PR DESCRIPTION
## Summary
- remove the existing placeholder `.brand-logo` element before inserting the uploaded logo image
- limit the `.has-logo` display rule to `img.brand-logo` so the placeholder stays hidden when a custom logo loads

## Testing
- python -m http.server 8000 (manual verification with and without assets/images/logo.png)


------
https://chatgpt.com/codex/tasks/task_e_68df3a1911ec8332bbace74da48e166f