### PR TITLE
Refactor navigation menus to build from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - Use hexadecimais (`#RRGGBB` ou `#RRGGBBAA` para transparências) e mantenha contraste mínimo de 4.5:1 entre `background`/`backgroundAccent` e `text`/`textSoft`.
 - `whatsappNumber`, `addressHtml` e `openingHours`
 - Blocos `navigation`, `hero`, `services`, `plans`, `testimonials`, `gallery`, `faq`, `contact` e `footer` para trocar textos, botões e listas
+  - Em `navigation.links` você pode adicionar ou remover quantos itens quiser; o menu desktop, mobile e o rodapé são atualizados automaticamente.
 - `social.instagram` e `social.tiktok` alimentam os ícones de redes no rodapé. Deixe a URL vazia para ocultar o link correspondente.
 - `thankYouPage` → título, texto e botão da página thanks.html (Netlify usa essa tela após cada envio)
 - Para **esconder seções sem editar HTML**, coloque `enabled: false` nos blocos:

--- a/TUTORIAL.txt
+++ b/TUTORIAL.txt
@@ -25,7 +25,7 @@ PASSO 1 — EDITAR CONFIG.JS
    - addressHtml → endereço (aceita <br/> para quebrar linha)
    - openingHours → dias e horários da sua operação
 3. Logo abaixo edite cada bloco de conteúdo:
-   - navigation → textos e links do menu/CTA (apague um item da lista para remover o link do site)
+   - navigation → textos e links do menu/CTA (adicione ou remova itens no array `links` e eles aparecem automaticamente no menu desktop, mobile e rodapé; o CTA segue `navigation.cta`)
    - hero → título, destaque, botões, badges e formulário da oferta
    - services, plans, testimonials, gallery, faq → títulos e listas dos cards
    - contact → opções do formulário, botões e badges

--- a/index.html
+++ b/index.html
@@ -26,22 +26,14 @@
         <strong>AuMiau</strong> <span class="sub">Petshop</span>
       <span class="brand-text">AuMiau</span></a>
       <nav class="nav-links" aria-label="Principal">
-        <a href="#servicos">Serviços</a>
-        <a href="#planos">Planos</a>
-        <a href="#depoimentos">Depoimentos</a>
-        <a href="#galeria">Galeria</a>
-        <a href="#contato" class="btn btn-sm">Agendar</a>
+        <!-- Links são inseridos dinamicamente via config-bind.js -->
       </nav>
       <button id="menuBtn" class="menu-btn" aria-label="Abrir menu" aria-controls="mobileMenu" aria-expanded="false">
         <span></span><span></span><span></span>
       </button>
     </div>
     <div id="mobileMenu" class="mobile-menu" hidden>
-      <a href="#servicos">Serviços</a>
-      <a href="#planos">Planos</a>
-      <a href="#depoimentos">Depoimentos</a>
-      <a href="#galeria">Galeria</a>
-      <a href="#contato" class="btn">Agendar</a>
+      <!-- Itens do menu mobile são construídos dinamicamente -->
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- prepare desktop and mobile navigation containers to be populated at runtime
- rebuild navigation, mobile, and footer menus from configuration and attach CTA links dynamically
- document that the navigation array controls all menus across the site

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df4142d1a48332a6264f1b0e9ae872